### PR TITLE
bump: Go 1.24 and utilize tool dependencies with gomod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24
 
       - uses: actions/cache@v4
         with:
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24
 
       - id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KeisukeYamashita/terraform-provider-butane
 
-go 1.23
+go 1.24
 
 require (
 	github.com/coreos/butane v0.23.0
@@ -94,3 +94,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
+
+tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
-)


### PR DESCRIPTION
## Why

From Go 1.24, we can finally manage the tools with `go.mod` 🚀 
Now, we can eliminate the tools-meta pattern.

Ref: [Managing dependencies - The Go Programming Language](https://tip.golang.org/doc/modules/managing-dependencies#tools)