### PR TITLE
fix: use hex-encoded SHA-256 hash for deterministic and safe ID gener…

### DIFF
--- a/butane/data_source_project.go
+++ b/butane/data_source_project.go
@@ -2,6 +2,8 @@ package butane
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 
 	butane "github.com/coreos/butane/config"
 	"github.com/coreos/butane/config/common"
@@ -63,7 +65,6 @@ func dataSourceConfig() *schema.Resource {
 }
 
 func dataSourceButaneReadContext(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	c := meta.(*client)
 	var diags diag.Diagnostics
 	opts := common.TranslateBytesOptions{}
 
@@ -89,7 +90,8 @@ func dataSourceButaneReadContext(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("parsing error: %s, strict: %t", r.String(), strict)
 	}
 
-	d.SetId(string(c.Hash.Sum(b)))
+	sum := sha256.Sum256(b)
+	d.SetId(hex.EncodeToString(sum[:]))
 	d.Set("ignition", string(b))
 	return diags
 }


### PR DESCRIPTION
resolve: #14 

This PR updates the way IDs are generated to ensure deterministic and human-readable identifiers.

Previously, IDs were set using `c.Hash.Sum(b)` and cast directly to a string.  
This approach had two issues:
- The resulting string could include raw binary data, which is unsafe and inconsistent.  
- The generated hash depended on the internal state of `c.Hash`, leading to potential non-determinism.

This change replaces that logic with:

```go
sum := sha256.Sum256(b)
d.SetId(hex.EncodeToString(sum[:]))
```